### PR TITLE
QueryBuilder should be transient?

### DIFF
--- a/usage.md
+++ b/usage.md
@@ -55,7 +55,8 @@ qb = {
             grammar = di1.getBean( "MySQLGrammar" ),
             utils = di1.getBean( "QueryUtils" ),
             returnFormat = "array"
-         });
+         })
+         .asTransient();
     }
   }
 }


### PR DESCRIPTION
I may have this wrong, but it is my understanding that wirebox creates transient objects by default, but fw/1 creates singletons by default. QueryBuilder looks to me like it should be a transient object so I have added the isTransient function to the di1 declaration.