### PR TITLE
Updated the cfc path for manual instructions

### DIFF
--- a/overview/installation-and-usage.md
+++ b/overview/installation-and-usage.md
@@ -21,8 +21,8 @@ moduleSettings = {
 If you are not using WireBox, just make sure to wire up the `Builder` object with the correct grammar:
 
 ```text
-var grammar = new qb.models.Query.Grammars.MySQLGrammar();
-var builder = new qb.models.Query.Builder( grammar );
+var grammar = new qb.models.Grammars.MySQLGrammar();
+var builder = new qb.models.Query.QueryBuilder( grammar );
 ```
 
 ## Integrating With FW/1


### PR DESCRIPTION
The path had the `.Query.` folder in the path when it's just in the `Grammar` folder when downloaded. I adjusted my code and it worked. Also the path was wrong for the Builder now as it needed to be called `QueryBuilder`